### PR TITLE
Variant manage resource

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ INCLUDE_DIRECTORIES("${qmcpack_SOURCE_DIR}/external_codes/boost_multi")
     Utilities/RunTimeManager.cpp
     Utilities/ProgressReportEngine.cpp
     Utilities/unit_conversion.cpp
+    Utilities/ResourceCollection.cpp
     OhmmsApp/ProjectData.cpp
     OhmmsApp/RandomNumberControl.cpp
     Numerics/OptimizableFunctorBase.cpp
@@ -152,6 +153,7 @@ IF(USE_OBJECT_TARGET)
 ELSE(USE_OBJECT_TARGET)
   ADD_LIBRARY(qmcutil ${UTILITIES})
 ENDIF(USE_OBJECT_TARGET)
+  TARGET_INCLUDE_DIRECTORIES(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Utilities")
   TARGET_LINK_LIBRARIES(qmcutil PUBLIC message containers qmcio)
   TARGET_LINK_LIBRARIES(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
 

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -1,0 +1,31 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RESOURCE_H
+#define QMCPLUSPLUS_RESOURCE_H
+
+#include <string>
+
+namespace qmcplusplus
+{
+class Resource
+{
+public:
+  Resource(const std::string& name) : name_(name) {}
+  virtual ~Resource()                 = default;
+  virtual Resource* makeClone() const = 0;
+  const std::string& getName() const { return name_; }
+
+private:
+  const std::string name_;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "ResourceCollection.h"
+
+namespace qmcplusplus
+{
+ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
+
+void ResourceCollection::printResources() {}
+
+size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
+{
+  size_t id = collection.size();
+  collection.emplace_back(std::move(res));
+  return id;
+}
+
+std::unique_ptr<Resource> ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
+
+void ResourceCollection::takebackResource(size_t id, std::unique_ptr<Resource>&& res)
+{
+  collection[id] = std::move(res);
+}
+
+} // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -10,12 +10,19 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "ResourceCollection.h"
-
+#include <iostream>
 namespace qmcplusplus
 {
 ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
 
-void ResourceCollection::printResources() {}
+void ResourceCollection::printResources()
+{
+  std::cout << "Resource Collection: " << getName() << '\n';
+  for (auto& res : collection)
+  {
+    std::visit([](auto& resource) { std::cout << resource->getName() << '\n'; }, res);
+  }
+}
 
 size_t ResourceCollection::addResource(ResourceWrapper&& res)
 {
@@ -26,9 +33,6 @@ size_t ResourceCollection::addResource(ResourceWrapper&& res)
 
 ResourceWrapper ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
 
-void ResourceCollection::takebackResource(size_t id, ResourceWrapper&& res)
-{
-  collection[id] = std::move(res);
-}
+void ResourceCollection::takebackResource(size_t id, ResourceWrapper&& res) { collection[id] = std::move(res); }
 
 } // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -17,16 +17,16 @@ ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
 
 void ResourceCollection::printResources() {}
 
-size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
+size_t ResourceCollection::addResource(ResourceWrapper&& res)
 {
   size_t id = collection.size();
   collection.emplace_back(std::move(res));
   return id;
 }
 
-std::unique_ptr<Resource> ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
+ResourceWrapper ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
 
-void ResourceCollection::takebackResource(size_t id, std::unique_ptr<Resource>&& res)
+void ResourceCollection::takebackResource(size_t id, ResourceWrapper&& res)
 {
   collection[id] = std::move(res);
 }

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -1,0 +1,39 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RESOURCECOLLECTION_H
+#define QMCPLUSPLUS_RESOURCECOLLECTION_H
+
+#include <string>
+#include <memory>
+#include <cstddef>
+#include <vector>
+#include "Resource.h"
+
+namespace qmcplusplus
+{
+class ResourceCollection
+{
+public:
+  ResourceCollection(const std::string& name);
+  const std::string& getName() const { return name_; }
+  void printResources();
+
+  size_t addResource(std::unique_ptr<Resource>&& res);
+  std::unique_ptr<Resource> lendResource(size_t id);
+  void takebackResource(size_t i, std::unique_ptr<Resource>&& res);
+
+private:
+  const std::string name_;
+  std::vector<std::unique_ptr<Resource>> collection;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -16,10 +16,17 @@
 #include <memory>
 #include <cstddef>
 #include <vector>
+#include <variant>
 #include "Resource.h"
+#include "type_traits/template_types.hpp"
+#include "tests/MemoryResource.h"
+#include "tests/TestResource2.h"
 
 namespace qmcplusplus
 {
+
+using ResourceWrapper = std::variant<UPtr<MemoryResource>,UPtr<TestResource2>>;
+
 class ResourceCollection
 {
 public:
@@ -27,13 +34,13 @@ public:
   const std::string& getName() const { return name_; }
   void printResources();
 
-  size_t addResource(std::unique_ptr<Resource>&& res);
-  std::unique_ptr<Resource> lendResource(size_t id);
-  void takebackResource(size_t i, std::unique_ptr<Resource>&& res);
+  size_t addResource(ResourceWrapper&& res);
+  ResourceWrapper lendResource(size_t id);
+  void takebackResource(size_t i, ResourceWrapper&& res);
 
 private:
   const std::string name_;
-  std::vector<std::unique_ptr<Resource>> collection;
+  std::vector<ResourceWrapper> collection;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 ADD_EXECUTABLE(${UTEST_EXE} test_rng.cpp test_parser.cpp test_timer.cpp test_runtime_manager.cpp
                             test_prime_set.cpp test_partition.cpp test_pooled_memory.cpp
+                            test_ResourceCollection.cpp
                             test_infostream.cpp test_output_manager.cpp test_StdRandom.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} catch_main qmcutil)
 

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+#include "ResourceCollection.h"
+
+namespace qmcplusplus
+{
+class MemoryResource : public Resource
+{
+public:
+  MemoryResource(const std::string& name) : Resource(name) {}
+
+  MemoryResource* makeClone() const override { return new MemoryResource(*this); }
+
+  std::vector<int> data;
+};
+
+TEST_CASE("Resource", "[utilities]")
+{
+  auto mem_res = std::make_unique<MemoryResource>("test_res");
+  mem_res->data.resize(5);
+
+  std::unique_ptr<MemoryResource> res_copy(mem_res->makeClone());
+  REQUIRE(res_copy->data.size() == 5);
+}
+
+class WFCResourceConsumer
+{
+public:
+  void createResource(ResourceCollection& collection)
+  {
+    external_memory_handle = std::make_unique<MemoryResource>("test_res");
+    external_memory_handle->data.resize(5);
+    resource_index = collection.addResource(std::move(external_memory_handle));
+  }
+
+  void acquireResource(ResourceCollection& collection)
+  {
+    auto res_ptr = dynamic_cast<MemoryResource*>(collection.lendResource(resource_index).release());
+    if (!res_ptr)
+      throw std::runtime_error("WFCResourceConsumer::acquireResource dynamic_cast failed");
+    external_memory_handle.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection)
+  {
+    collection.takebackResource(resource_index, std::move(external_memory_handle));
+  }
+
+  MemoryResource* getPtr() const { return external_memory_handle.get(); }
+
+private:
+  std::unique_ptr<MemoryResource> external_memory_handle;
+  size_t resource_index = -1;
+};
+
+TEST_CASE("ResourceCollection", "[utilities]")
+{
+  ResourceCollection res_collection("abc");
+  WFCResourceConsumer wfc;
+  REQUIRE(wfc.getPtr() == nullptr);
+
+  wfc.createResource(res_collection);
+  REQUIRE(wfc.getPtr() == nullptr);
+
+  wfc.acquireResource(res_collection);
+  REQUIRE(wfc.getPtr() != nullptr);
+  REQUIRE(wfc.getPtr()->data.size() == 5);
+
+  wfc.releaseResource(res_collection);
+  REQUIRE(wfc.getPtr() == nullptr);
+}
+
+} // namespace qmcplusplus

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -60,6 +60,7 @@ TEST_CASE("ResourceCollection", "[utilities]")
   wfc.createResource(res_collection);
   REQUIRE(wfc.getPtr() == nullptr);
 
+  res_collection.printResources();
   wfc.acquireResource(res_collection);
   REQUIRE(wfc.getPtr() != nullptr);
   REQUIRE(wfc.getPtr()->data.size() == 5);

--- a/src/type_traits/template_types.hpp
+++ b/src/type_traits/template_types.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <functional>
 #include <memory>
+#include <cassert>
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
Variant easily replaces the base class and other than dynamic_cast<ResourceType> becoming std::get<ResourceType> consumer code is slightly reduced but still needs to "unwrap" the resource.

This could allow the resources to use value semantics with a bit more work.